### PR TITLE
feat: stage 1 - counter and notes (static)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,32 @@
+// Stage 1 counter and notes functionality
+// No persistence; pure DOM manipulation
+
+const valueEl = document.getElementById('value');
+const incrementBtn = document.getElementById('increment');
+const decrementBtn = document.getElementById('decrement');
+const resetBtn = document.getElementById('reset');
+
+let count = 0;
+
+function render() {
+  valueEl.textContent = String(count);
+  valueEl.parentElement.classList.toggle('negative', count < 0);
+  resetBtn.disabled = count === 0;
+}
+
+incrementBtn.addEventListener('click', () => {
+  count += 1;
+  render();
+});
+
+decrementBtn.addEventListener('click', () => {
+  count -= 1;
+  render();
+});
+
+resetBtn.addEventListener('click', () => {
+  count = 0;
+  render();
+});
+
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Pocket Counter Notes</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="card">
+        <div class="counter" aria-live="polite">
+          <span id="value">0</span>
+        </div>
+        <div class="controls">
+          <button id="increment" type="button">+1</button>
+          <button id="decrement" type="button">&minus;1</button>
+          <button id="reset" type="button" disabled>Reset</button>
+        </div>
+        <label for="notes" class="notes-label">Notes</label>
+        <textarea id="notes" rows="4" placeholder="Write your notes here..."></textarea>
+      </section>
+    </main>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,91 @@
+:root {
+  --color-bg: #f5f5f5;
+  --color-card-bg: #ffffff;
+  --color-text: #222222;
+  --color-primary: #0066ee;
+  --color-button-text: #ffffff;
+  --color-negative: #cc0000;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+  --radius: 0.5rem;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.card {
+  background: var(--color-card-bg);
+  padding: var(--space-lg);
+  border-radius: var(--radius);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  width: min(90%, 400px);
+}
+
+.counter {
+  font-size: 3rem;
+  margin-bottom: var(--space-md);
+}
+
+.counter.negative {
+  color: var(--color-negative);
+}
+
+.controls {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: center;
+  margin-bottom: var(--space-md);
+}
+
+button {
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-radius: var(--radius);
+  background: var(--color-primary);
+  color: var(--color-button-text);
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  filter: brightness(1.1);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.notes-label {
+  display: block;
+  margin-bottom: var(--space-sm);
+  font-weight: bold;
+  text-align: left;
+}
+
+textarea {
+  width: 100%;
+  padding: var(--space-sm);
+  border: 1px solid #cccccc;
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 6rem;
+  font-family: inherit;
+}


### PR DESCRIPTION
## Summary
- implement semantic counter and notes UI
- highlight negative counts in red and disable reset at zero
- add button hover feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adac887e6c8324a93d7d953ddc33eb