### PR TITLE
feat: Pomodoro timer with animated ring, persistence, and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # pocket-counter-notes
+
+## Pomodoro
+
+The app now includes a simple Pomodoro timer with focus, short break and long break modes. It features an animated progress ring, keyboard shortcuts and state persistence so the timer keeps running even if you reload the page.

--- a/app.js
+++ b/app.js
@@ -30,3 +30,186 @@ resetBtn.addEventListener('click', () => {
 });
 
 render();
+
+// Pomodoro timer
+const pomodoroCard = document.getElementById('pomodoro-card');
+const timeEl = document.getElementById('pomodoro-time');
+const modeButtons = pomodoroCard.querySelectorAll('.modes button');
+const startBtn = document.getElementById('pomodoro-start');
+const resetTimerBtn = document.getElementById('pomodoro-reset');
+const durationSelect = document.getElementById('pomodoro-duration');
+const ringProgress = pomodoroCard.querySelector('.ring-progress');
+
+const RADIUS = 45;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+ringProgress.style.strokeDasharray = CIRCUMFERENCE;
+
+let pState = {
+  mode: 'focus',
+  durations: { focus: 25 * 60 * 1000, short: 5 * 60 * 1000, long: 15 * 60 * 1000 },
+  endTime: null,
+  remaining: 25 * 60 * 1000,
+  running: false,
+};
+
+let tickId;
+
+function saveState() {
+  localStorage.setItem('pomodoroState', JSON.stringify(pState));
+}
+
+function applyMode() {
+  pomodoroCard.classList.remove('focus', 'short', 'long');
+  pomodoroCard.classList.add(pState.mode);
+  modeButtons.forEach((btn) => {
+    const active = btn.dataset.mode === pState.mode;
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+function renderTime() {
+  const total = pState.durations[pState.mode];
+  const minutes = Math.floor(pState.remaining / 60000);
+  const seconds = Math.floor((pState.remaining % 60000) / 1000);
+  timeEl.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  const fraction = pState.remaining / total;
+  const offset = CIRCUMFERENCE * (1 - fraction);
+  ringProgress.style.strokeDashoffset = offset;
+}
+
+function updateControls() {
+  startBtn.textContent = pState.running ? 'Pause' : 'Start';
+  resetTimerBtn.disabled = pState.running || pState.remaining === pState.durations[pState.mode];
+}
+
+function tick() {
+  const now = Date.now();
+  pState.remaining = Math.max(0, pState.endTime - now);
+  renderTime();
+  if (pState.remaining > 0) {
+    tickId = requestAnimationFrame(tick);
+  } else {
+    pState.running = false;
+    pState.endTime = null;
+    updateControls();
+    saveState();
+    if ('Notification' in window && Notification.permission === 'granted') {
+      const message = pState.mode === 'focus' ? 'Focus session complete' : 'Break finished';
+      new Notification(message);
+    }
+  }
+}
+
+function startTimer() {
+  if (pState.running) return;
+  pState.endTime = Date.now() + pState.remaining;
+  pState.running = true;
+  tickId = requestAnimationFrame(tick);
+  updateControls();
+  saveState();
+  if ('Notification' in window && Notification.permission === 'default') {
+    Notification.requestPermission();
+  }
+}
+
+function pauseTimer() {
+  if (!pState.running) return;
+  pState.remaining = Math.max(0, pState.endTime - Date.now());
+  pState.running = false;
+  pState.endTime = null;
+  cancelAnimationFrame(tickId);
+  updateControls();
+  saveState();
+}
+
+function resetTimer() {
+  pState.running = false;
+  pState.endTime = null;
+  cancelAnimationFrame(tickId);
+  pState.remaining = pState.durations[pState.mode];
+  renderTime();
+  updateControls();
+  saveState();
+}
+
+function setMode(mode) {
+  if (pState.mode === mode) return;
+  pState.mode = mode;
+  pState.running = false;
+  pState.endTime = null;
+  pState.remaining = pState.durations[mode];
+  durationSelect.value = pState.durations[mode] / 60000;
+  applyMode();
+  renderTime();
+  updateControls();
+  saveState();
+  startBtn.focus();
+}
+
+modeButtons.forEach((btn) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+});
+
+startBtn.addEventListener('click', () => {
+  pState.running ? pauseTimer() : startTimer();
+});
+
+resetTimerBtn.addEventListener('click', resetTimer);
+
+durationSelect.addEventListener('change', () => {
+  const minutes = Number(durationSelect.value);
+  pState.durations[pState.mode] = minutes * 60000;
+  resetTimer();
+});
+
+document.addEventListener('keydown', (e) => {
+  const tag = e.target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
+  switch (e.key) {
+    case ' ':
+      e.preventDefault();
+      pState.running ? pauseTimer() : startTimer();
+      break;
+    case 'b':
+      setMode('short');
+      break;
+    case 'l':
+      setMode('long');
+      break;
+    case 'f':
+      setMode('focus');
+      break;
+  }
+});
+
+function loadPomodoro() {
+  const saved = localStorage.getItem('pomodoroState');
+  if (saved) {
+    try {
+      const data = JSON.parse(saved);
+      if (data) {
+        pState = { ...pState, ...data };
+      }
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  if (pState.running && pState.endTime) {
+    pState.remaining = Math.max(0, pState.endTime - Date.now());
+    if (pState.remaining === 0) {
+      pState.running = false;
+      pState.endTime = null;
+    }
+  } else {
+    pState.remaining = pState.durations[pState.mode];
+  }
+  applyMode();
+  durationSelect.value = pState.durations[pState.mode] / 60000;
+  renderTime();
+  updateControls();
+  if (pState.running) {
+    tickId = requestAnimationFrame(tick);
+  }
+}
+
+loadPomodoro();

--- a/index.html
+++ b/index.html
@@ -19,6 +19,42 @@
         <label for="notes" class="notes-label">Notes</label>
         <textarea id="notes" rows="4" placeholder="Write your notes here..."></textarea>
       </section>
+      <section class="card pomodoro focus" id="pomodoro-card" aria-label="Pomodoro timer">
+        <h2>Pomodoro</h2>
+        <div class="timer" role="timer" aria-live="polite">
+          <svg viewBox="0 0 100 100" class="ring" aria-hidden="true">
+            <circle class="ring-bg" cx="50" cy="50" r="45"></circle>
+            <circle class="ring-progress" cx="50" cy="50" r="45"></circle>
+          </svg>
+          <div class="time" id="pomodoro-time">25:00</div>
+        </div>
+        <div class="modes" role="group" aria-label="Timer modes">
+          <button type="button" data-mode="focus" aria-pressed="true">Focus</button>
+          <button type="button" data-mode="short" aria-pressed="false">Short break</button>
+          <button type="button" data-mode="long" aria-pressed="false">Long break</button>
+        </div>
+        <div class="pomodoro-controls">
+          <button id="pomodoro-start" type="button">Start</button>
+          <button id="pomodoro-reset" type="button" disabled>Reset</button>
+          <label for="pomodoro-duration" class="sr-only">Duration</label>
+          <select id="pomodoro-duration">
+            <option value="1">1 min</option>
+            <option value="5">5 min</option>
+            <option value="10">10 min</option>
+            <option value="15">15 min</option>
+            <option value="20">20 min</option>
+            <option value="25" selected>25 min</option>
+            <option value="30">30 min</option>
+            <option value="45">45 min</option>
+            <option value="60">60 min</option>
+          </select>
+        </div>
+      </section>
+      <section class="help">
+        <h2>Help</h2>
+        <p><strong>Shortcuts:</strong> Space &ndash; start/pause, f &ndash; focus, b &ndash; short break, l &ndash; long break.</p>
+        <p>The timer stores its state using the system clock so it can keep running if you reload.</p>
+      </section>
     </main>
     <script src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -5,11 +5,28 @@
   --color-primary: #0066ee;
   --color-button-text: #ffffff;
   --color-negative: #cc0000;
+  --color-focus-ring: #0066ee;
+  --color-short-ring: #009e4f;
+  --color-long-ring: #c53f3f;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
   --space-lg: 2rem;
   --radius: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1e1e1e;
+    --color-card-bg: #2c2c2c;
+    --color-text: #f5f5f5;
+    --color-primary: #4d90fe;
+    --color-button-text: #ffffff;
+    --color-negative: #ff6a6a;
+    --color-focus-ring: #4d90fe;
+    --color-short-ring: #2ebf4f;
+    --color-long-ring: #e04343;
+  }
 }
 
 body {
@@ -18,9 +35,17 @@ body {
   background: var(--color-bg);
   color: var(--color-text);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
+  padding: var(--space-lg) 0;
   min-height: 100vh;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  align-items: center;
 }
 
 .card {
@@ -68,7 +93,8 @@ button:disabled {
 }
 
 button:focus-visible,
-textarea:focus-visible {
+textarea:focus-visible,
+select:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
@@ -88,4 +114,99 @@ textarea {
   resize: vertical;
   min-height: 6rem;
   font-family: inherit;
+}
+
+.pomodoro .timer {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto var(--space-md);
+}
+
+.pomodoro .ring {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.pomodoro .ring-bg,
+.pomodoro .ring-progress {
+  fill: none;
+  stroke-width: 10;
+}
+
+.pomodoro .ring-bg {
+  stroke: var(--color-card-bg);
+}
+
+.pomodoro .ring-progress {
+  stroke: var(--color-focus-ring);
+  stroke-dasharray: 283;
+  stroke-dashoffset: 0;
+  transition: stroke 0.3s linear;
+}
+
+.pomodoro.short .ring-progress {
+  stroke: var(--color-short-ring);
+}
+
+.pomodoro.long .ring-progress {
+  stroke: var(--color-long-ring);
+}
+
+.pomodoro .time {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+}
+
+.modes {
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: center;
+  margin-bottom: var(--space-md);
+}
+
+.modes button {
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+}
+
+.modes button[aria-pressed='true'] {
+  background: var(--color-primary);
+  color: var(--color-button-text);
+}
+
+.pomodoro-controls {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: center;
+  align-items: center;
+}
+
+select {
+  padding: var(--space-sm);
+  border-radius: var(--radius);
+  border: 1px solid #cccccc;
+  font-size: 1rem;
+}
+
+.help {
+  width: min(90%, 400px);
+  font-size: 0.875rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
## Summary
- add Pomodoro timer card with animated progress ring and keyboard shortcuts
- persist timer state and notify when sessions finish
- document new timer in README

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68adb7fced0483249f0fa4fb0d555086